### PR TITLE
migrate from `rusty_s3` to `s3-simple`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 [features]
 default = []
 cli = ["s3", "streaming", "dep:clap", "dep:colored", "dep:home", "dep:rpassword"]
-s3 = ["streaming", "dep:reqwest", "dep:rusty-s3", "dep:tokio-util"]
+s3 = ["streaming", "dep:reqwest", "dep:s3-simple", "dep:tokio-util"]
 streaming = ["dep:reqwest"]
 
 [dependencies]
@@ -47,8 +47,9 @@ rpassword = { version = "7.3.1", optional = true }
 reqwest = { version = "0.12.3", optional = true, default-features = false, features = [
     "json", "rustls-tls", "stream"
 ] }
-rusty-s3 = { version = "0.5.0", optional = true }
-tokio-util = { version = "0.7.10", optional = true, features = ["full"] }
+s3-simple = { path = "../s3-simple", optional = true }
+#s3-simple = { version = "0.3.0", optional = true }
+tokio-util = { version = "0.7.10", optional = true, features = ["io"] }
 
 # std
 #[target.'cfg(not(feature = "no-std"))'.dependencies]
@@ -62,5 +63,5 @@ lazy_static = "1.1.0"
 
 [dev-dependencies]
 cryptr = { path = ".", features = ["cli"] }
-rstest = "0.19.0"
+rstest = "0.21.0"
 tokio-test = "0.4.3"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,8 +1,8 @@
 use crate::cli::actions::Action;
 use crate::cli::args::{Args, ArgsKeys, ArgsKeysConvert, ArgsS3};
 use clap::Parser;
-use tracing::debug;
 use cryptr::CryptrError;
+use tracing::debug;
 
 mod actions;
 mod args;
@@ -35,7 +35,7 @@ pub async fn run() -> Result<(), CryptrError> {
         Args::S3(args) => match args {
             ArgsS3::Show => actions::s3_show().await?,
             ArgsS3::Update => actions::s3_update().await?,
-            ArgsS3::List(args) => actions::s3_list_buckets(args).await?,
+            ArgsS3::List(args) => actions::s3_list(args).await?,
         },
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,12 @@ impl CryptrError {
     }
 }
 
+impl From<CryptrError> for std::io::Error {
+    fn from(value: CryptrError) -> Self {
+        Self::new(std::io::ErrorKind::Other, value.to_string())
+    }
+}
+
 impl From<std::io::Error> for CryptrError {
     fn from(value: Error) -> Self {
         Self::Generic(value.to_string())
@@ -133,6 +139,13 @@ impl From<rand::Error> for CryptrError {
 impl From<reqwest::Error> for CryptrError {
     fn from(value: reqwest::Error) -> Self {
         Self::Generic(value.to_string())
+    }
+}
+
+#[cfg(feature = "s3")]
+impl From<s3_simple::S3Error> for CryptrError {
+    fn from(value: s3_simple::S3Error) -> Self {
+        Self::S3(value.to_string())
     }
 }
 


### PR DESCRIPTION
This migration get's rid of presigned URL's in favor of signed headers.  
Since `s3_simple` is as well compatible with Garage, we will get this compatibility for `cryptr` out of the box as well.