### PR TITLE
KdfValue and EncKeys improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use stream::writer::{file_writer::FileWriter, memory_writer::MemoryWriter, S
 pub use value::{EncAlg, EncValue, EncValueHeader, EncVersion};
 
 pub mod encryption;
-pub(crate) mod kdf;
+pub mod kdf;
 /// Encryption Keys
 pub mod keys;
 /// Streaming encryption / decryption


### PR DESCRIPTION
Allow creating EncKeys from KdfValue. Fix KdfValue variables not having the right Param variables. Add a const variable for output len.

### Why?
Bug in the ID from KdfValue before this. No matter what the Params' values, KdfValue always had the same static values.
I'm using this crate in production on very low memory IOT devices, so I'm just making things easier.