### PR TITLE
Fix: error during CLI `keys new-random`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and then maybe return it as an async HTTP response.
 The `ChannelReader` does NOT implement a decryption logic, because it does not make much sense. If you want to decrypt
 in-memory values, just stick to the already existing `MemoryReader`.
 
+This release also fixes a bug for the CLI, which could throw an unexpected error during `keys new-random` when the
+config dir does not exist yet.
+
 ## v0.6.2
 
 Fixes a bug in `KdfValue::new_with_params()`, which ignored `m_cost`, `t_cost`, `p_cost` from the params and used the

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -198,7 +198,7 @@ pub async fn convert_legacy_key() -> Result<(), CryptrError> {
 pub async fn new_random_key(args: ArgsKeysNew) -> Result<(), CryptrError> {
     println!("Generating a new random encryption key");
 
-    let keys = match EncKeys::read_from_config() {
+    let keys = match EncKeys::read_from_config().await {
         Ok(mut keys) => {
             if let Some(id) = args.with_id {
                 keys.append_new_random_with_id(id)?;
@@ -232,7 +232,7 @@ pub async fn list_keys(args: ArgsKeysList) -> Result<(), CryptrError> {
     let keys = if let Some(path) = &args.file {
         EncKeys::read_from_file(path)?
     } else {
-        EncKeys::read_from_config()?
+        EncKeys::read_from_config().await?
     };
 
     println!(

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -100,7 +100,7 @@ pub struct EncConfig {
 
 impl EncConfig {
     pub async fn read() -> Result<Self, CryptrError> {
-        let path = EncKeys::config_path()?;
+        let path = EncKeys::config_path().await?;
         Self::read_from_file(&path).await
     }
 
@@ -114,7 +114,7 @@ impl EncConfig {
     }
 
     pub async fn save(&self) -> Result<(), CryptrError> {
-        let path = EncKeys::config_path()?;
+        let path = EncKeys::config_path().await?;
         self.save_to_file(&path).await
     }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -150,11 +150,13 @@ impl EncKeys {
     ///
     /// Available with feature `cli` only
     #[cfg(feature = "cli")]
-    pub fn config_path() -> Result<String, CryptrError> {
+    pub async fn config_path() -> Result<String, CryptrError> {
         let home_path = home::home_dir().ok_or(CryptrError::File("Cannot get $HOME"))?;
         let home_str = home_path
             .to_str()
             .ok_or(CryptrError::File("Cannot convert $HOME path to str"))?;
+
+        fs::create_dir_all(format!("{home_str}/.cryptr")).await?;
 
         #[cfg(target_family = "unix")]
         let path = format!("{home_str}/.cryptr/config");
@@ -199,8 +201,8 @@ impl EncKeys {
     ///
     /// Available with feature `cli` only
     #[cfg(feature = "cli")]
-    pub fn read_from_config() -> Result<Self, CryptrError> {
-        let path = Self::config_path()?;
+    pub async fn read_from_config() -> Result<Self, CryptrError> {
+        let path = Self::config_path().await?;
         if dotenvy::from_filename(path).is_err() {
             Err(CryptrError::Config("Config has not been set up yet"))
         } else {


### PR DESCRIPTION
Fixes an issue when the config dir does not exist at all yet and the CLI executes `keys new-random`.